### PR TITLE
Terminal compatibility fixes + ANSI music

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 !config.go
 !config.json
 !cp437_enhanced.go
+!ansi_music.go
 !directory_handlers.go
 !go.mod
 !go.sum
@@ -34,6 +35,7 @@
 !static/bbs_seed.json
 !static/directory.js
 !static/app.js
+!static/ansi-music.js
 !static/favicon.svg
 
 # Allow GitHub Actions workflows

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@
 !.github/workflows/ci.yml
 
 # By default, everything else remains ignored
+# Local debug artifacts
+*.log
+*.tmp
+*.swp
+*.DS_Store
+node_modules/

--- a/ansi_music.go
+++ b/ansi_music.go
@@ -1,0 +1,158 @@
+package main
+
+// Minimal ANSI music detector for CSI |/M/N sequences.
+// Detects sequences beginning with ESC [ ( '|' | 'M' | 'N' ) and consumes
+// until a terminator: BEL (0x07), SO (0x0E), SI (0x0F), ST (ESC \), or the
+// next ESC (which is presumed to start a new sequence). If a sequence spans
+// chunks, it is buffered until the terminator arrives.
+
+type AnsiMusicEmitter func(payload string)
+
+type AnsiMusicProcessor struct {
+    emit   AnsiMusicEmitter
+    inSeq  bool
+    buffer []byte // from ESC [ X ... (intro included)
+}
+
+func NewAnsiMusicProcessor(emit AnsiMusicEmitter) *AnsiMusicProcessor {
+    return &AnsiMusicProcessor{emit: emit, buffer: make([]byte, 0, 256)}
+}
+
+// Process returns the input with any detected music sequences removed.
+// The returned bool indicates whether any sequence was consumed.
+func (p *AnsiMusicProcessor) Process(data []byte) ([]byte, bool) {
+    if p == nil || len(data) == 0 {
+        return data, false
+    }
+
+    consumed := false
+
+    // If in the middle of a buffered sequence, append and try to finish
+    if p.inSeq {
+        p.buffer = append(p.buffer, data...)
+        done, tail := p.tryEmitFromBuffer()
+        if done {
+            consumed = true
+            // Process any trailing bytes recursively
+            rem, more := p.Process(tail)
+            return rem, consumed || more
+        }
+        // Still incomplete: suppress all
+        return []byte{}, true
+    }
+
+    out := make([]byte, 0, len(data))
+    i := 0
+    for i < len(data) {
+        b := data[i]
+        if b == 0x1B && i+2 < len(data) && data[i+1] == '[' { // ESC [
+            intro := data[i+2]
+            if intro == '|' || intro == 'M' || intro == 'N' {
+                // Flush non-music bytes before the introducer
+                out = append(out, data[:i]...)
+                // Search for terminator in remaining data
+                j := i + 3
+                term := -1
+                termEsc := false
+                for j < len(data) {
+                    if data[j] == 0x07 || data[j] == 0x0E || data[j] == 0x0F { // BEL/SO/SI
+                        term = j
+                        break
+                    }
+                    if data[j] == 0x1B { // ESC
+                        if j+1 < len(data) && data[j+1] == '\\' { // ST
+                            term = j
+                            termEsc = true
+                            break
+                        }
+                        term = j // leave ESC for next parser
+                        break
+                    }
+                    j++
+                }
+                if term != -1 {
+                    payload := string(data[i+3 : term])
+                    if p.emit != nil && len(payload) > 0 {
+                        p.emit(payload)
+                    }
+                    // Continue parsing tail
+                    var tail []byte
+                    if termEsc {
+                        if term+2 <= len(data) {
+                            tail = data[term+2:]
+                        }
+                    } else if data[term] == 0x07 || data[term] == 0x0E || data[term] == 0x0F {
+                        if term+1 <= len(data) {
+                            tail = data[term+1:]
+                        }
+                    } else {
+                        tail = data[term:]
+                    }
+                    data = tail
+                    i = 0
+                    consumed = true
+                    continue
+                }
+                // No terminator found: buffer from introducer and mark inSeq
+                p.buffer = p.buffer[:0]
+                p.buffer = append(p.buffer, data[i:]...)
+                p.inSeq = true
+                consumed = true
+                return out, consumed
+            }
+        }
+        i++
+    }
+    // No music introducer found; pass through
+    out = append(out, data...)
+    return out, consumed
+}
+
+// tryEmitFromBuffer searches buffer for a terminator, emits payload if found,
+// and returns (done, tail) where tail are bytes after the terminator.
+func (p *AnsiMusicProcessor) tryEmitFromBuffer() (bool, []byte) {
+    if !p.inSeq || len(p.buffer) < 3 {
+        return false, nil
+    }
+    j := 3
+    term := -1
+    termEsc := false
+    for j < len(p.buffer) {
+        if p.buffer[j] == 0x07 || p.buffer[j] == 0x0E || p.buffer[j] == 0x0F {
+            term = j
+            break
+        }
+        if p.buffer[j] == 0x1B {
+            if j+1 < len(p.buffer) && p.buffer[j+1] == '\\' {
+                term = j
+                termEsc = true
+                break
+            }
+            term = j
+            break
+        }
+        j++
+    }
+    if term == -1 {
+        return false, nil
+    }
+    payload := string(p.buffer[3:term])
+    if p.emit != nil && len(payload) > 0 {
+        p.emit(payload)
+    }
+    var tail []byte
+    if termEsc {
+        if term+2 < len(p.buffer) {
+            tail = append(tail, p.buffer[term+2:]...)
+        }
+    } else if p.buffer[term] == 0x07 || p.buffer[term] == 0x0E || p.buffer[term] == 0x0F {
+        if term+1 < len(p.buffer) {
+            tail = append(tail, p.buffer[term+1:]...)
+        }
+    } else {
+        tail = append(tail, p.buffer[term:]...)
+    }
+    p.inSeq = false
+    p.buffer = p.buffer[:0]
+    return true, tail
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
     "net/http"
     neturl "net/url"
     "os"
+    "strconv"
     "strings"
     "sync"
     "time"
@@ -109,6 +110,22 @@ type Client struct {
     // Telnet binary mode negotiation state
     telnetBinaryTX bool // We WILL transmit binary
     telnetBinaryRX bool // Remote WILL transmit binary
+
+    // Telnet negotiation state
+    telnetNAWS     bool // NAWS negotiated (we WILL NAWS)
+    telnetTTYPE    bool // TTYPE negotiated (we WILL TTYPE)
+
+    // Terminal dimensions (fixed BBS-friendly sizes)
+    termCols int
+    termRows int
+
+    // Lightweight cursor tracking for CPR replies
+    cursorRow int
+    cursorCol int
+    cursorSeqBuf []byte
+
+    // ANSI music processor (CSI | sequences)
+    music *AnsiMusicProcessor
 }
 
 // Global list of approved BBSes (loaded from both config and bbs.json)
@@ -224,7 +241,16 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
         done:         make(chan bool),
         charset:      "CP437",
         ansiEnhanced: NewANSIEnhancedProcessor(debugMode),
+        termCols:     80,
+        termRows:     25,
+        cursorRow:    1,
+        cursorCol:    1,
+        cursorSeqBuf: make([]byte, 0, 64),
     }
+    // Music emitter sends a JSON message to the client; keep simple payload
+    client.music = NewAnsiMusicProcessor(func(payload string) {
+        client.sendJSON(Message{Type: "music", Message: payload})
+    })
 
 	// Start ping ticker for keepalive
 	ticker := time.NewTicker(30 * time.Second)
@@ -293,15 +319,27 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request) {
             }
 		case "data":
 			client.sendToRemote(msg.Data)
-		case "resize":
-			// Update PTY size for SSH sessions if present
-			client.mu.Lock()
-			sshSession := client.sshSession
-			client.mu.Unlock()
-			if sshSession != nil && msg.Cols > 0 && msg.Rows > 0 {
-				// Note: WindowChange takes rows, cols order
-				_ = sshSession.WindowChange(msg.Rows, msg.Cols)
-			}
+    case "resize":
+        // Update PTY size for SSH sessions if present
+        client.mu.Lock()
+        sshSession := client.sshSession
+        client.mu.Unlock()
+        if sshSession != nil && msg.Cols > 0 && msg.Rows > 0 {
+            // Note: WindowChange takes rows, cols order
+            _ = sshSession.WindowChange(msg.Rows, msg.Cols)
+        }
+        // Accept only fixed BBS-friendly sizes for telnet NAWS
+        if (msg.Cols == 80 && msg.Rows == 25) || (msg.Cols == 100 && msg.Rows == 31) {
+            client.mu.Lock()
+            client.termCols = msg.Cols
+            client.termRows = msg.Rows
+            telnetConn := client.telnet
+            telnetNAWS := client.telnetNAWS
+            client.mu.Unlock()
+            if telnetConn != nil && telnetNAWS {
+                client.sendTelnetNAWS()
+            }
+        }
 		case "setCharset":
 			client.charset = msg.Charset
 		case "getBBSList":
@@ -377,7 +415,7 @@ func (c *Client) connectTelnet(host string, port int) {
 // readTelnet pumps data from the telnet connection to the browser, handling
 // telnet negotiations, CP437 conversion, ANSI processing, and ZMODEM detection.
 func (c *Client) readTelnet() {
-	buffer := make([]byte, 8192)
+    buffer := make([]byte, 8192)
 
 	for {
 		c.mu.Lock()
@@ -419,9 +457,9 @@ func (c *Client) readTelnet() {
 			}
 
 			// Feed RAW data to Zmodem receiver if available (not cleaned!)
-			var cleanData []byte
-			if c.zmodemReceiver != nil {
-				if remaining, consumed := c.zmodemReceiver.ProcessData(rawData); consumed {
+            var cleanData []byte
+            if c.zmodemReceiver != nil {
+                if remaining, consumed := c.zmodemReceiver.ProcessData(rawData); consumed {
 					// During transfer, optionally show minimal status to terminal or suppress
 					// Suppress transfer bytes from terminal output
 					if len(remaining) > 0 {
@@ -458,10 +496,24 @@ func (c *Client) readTelnet() {
 
             // Only send to terminal if not in active ZMODEM transfer and not in pre-suppression window
             if len(cleanData) > 0 && (c.zmodemReceiver == nil || !c.zmodemReceiver.Active()) && !c.suppressZmodem {
+                // ANSI Music: detect and emit events, suppressing music sequences
+                if c.music != nil {
+                    if remaining, consumed := c.music.Process(cleanData); consumed {
+                        cleanData = remaining
+                    }
+                }
+                // Respond to terminal queries if enabled
+                if os.Getenv("TERM_ANSWERS") == "true" {
+                    c.handleTerminalQueries(cleanData)
+                }
                 // Process ANSI sequences with enhanced processor
                 processedData := cleanData
-                if c.ansiEnhanced != nil {
+                if c.ansiEnhanced != nil && os.Getenv("ANSI_NORMALIZE") != "false" {
                     processedData = c.ansiEnhanced.ProcessANSIData(cleanData)
+                }
+                // Optional hex dump for diagnostics
+                if os.Getenv("HEX_DUMP") == "true" {
+                    c.debugHexDump("TELNET->CLIENT", processedData, 256)
                 }
                 
                 // Convert CP437 to UTF-8 if needed
@@ -474,12 +526,17 @@ func (c *Client) readTelnet() {
                 }
 
 				encoded := base64.StdEncoding.EncodeToString(outputData)
-				c.sendJSON(Message{
-					Type:     "data",
-					Data:     encoded,
-					Encoding: "base64",
-				})
-			}
+                c.sendJSON(Message{
+                    Type:     "data",
+                    Data:     encoded,
+                    Encoding: "base64",
+                })
+
+                // Update our lightweight cursor tracker if enabled
+                if os.Getenv("CURSOR_TRACK") == "true" {
+                    c.updateCursorFrom(processedData)
+                }
+            }
 		}
 	}
 }
@@ -504,77 +561,123 @@ func (c *Client) hasZmodemSignature(data []byte) bool {
 // processTelnetData filters and responds to telnet negotiations and returns
 // a cleaned stream suitable for terminal rendering and ZMODEM processing.
 func (c *Client) processTelnetData(data []byte) []byte {
-	const (
-		IAC  = 255
-		DONT = 254
-		DO   = 253
-		WONT = 252
-		WILL = 251
-		SB   = 250
-		SE   = 240
-	)
+    const (
+        IAC  = 255
+        DONT = 254
+        DO   = 253
+        WONT = 252
+        WILL = 251
+        SB   = 250
+        SE   = 240
+    )
+
+    // Telnet options
+    const (
+        TELOPT_TTYPE = 24
+        TELOPT_NAWS  = 31
+    )
+    const (
+        TELQUAL_IS   = 0
+        TELQUAL_SEND = 1
+    )
 
 	var clean []byte
 	var response []byte
 	i := 0
 
 	for i < len(data) {
-		if data[i] == IAC {
-			if i+1 < len(data) {
-				if data[i+1] == IAC {
-					// Escaped IAC
-					clean = append(clean, IAC)
-					i += 2
-				} else if i+2 < len(data) && data[i+1] >= SE && data[i+1] <= DONT {
-					cmd := data[i+1]
-					option := data[i+2]
+        if data[i] == IAC {
+            if i+1 < len(data) {
+                if data[i+1] == IAC {
+                    // Escaped IAC
+                    clean = append(clean, IAC)
+                    i += 2
+                } else if i+2 < len(data) && data[i+1] >= SE && data[i+1] <= DONT {
+                    cmd := data[i+1]
+                    option := data[i+2]
 
-					// Respond to telnet negotiations
-					// Accept BINARY transmission (option 0) for reliable ZMODEM transfers
-					const BINARY = 0
-					if cmd == DO {
-						if option == BINARY {
-							response = append(response, IAC, WILL, option)
-							c.telnetBinaryTX = true
-						} else {
-							response = append(response, IAC, WONT, option)
-						}
-					} else if cmd == DONT {
-						// Acknowledge with WONT
-						response = append(response, IAC, WONT, option)
-						if option == BINARY {
-							c.telnetBinaryTX = false
-						}
-					} else if cmd == WILL {
-						if option == BINARY {
-							response = append(response, IAC, DO, option)
-							c.telnetBinaryRX = true
-						} else {
-							response = append(response, IAC, DONT, option)
-						}
-					} else if cmd == WONT {
-						// Acknowledge with DONT
-						response = append(response, IAC, DONT, option)
-						if option == BINARY {
-							c.telnetBinaryRX = false
-						}
-					}
-					i += 3
-				} else if data[i+1] == SB {
-					// Skip subnegotiation
-					j := i + 2
-					for j < len(data)-1 {
-						if data[j] == IAC && data[j+1] == SE {
-							i = j + 2
-							break
-						}
-						j++
-					}
-				} else {
-					i += 2
-				}
-			} else {
-				i++
+                    // Respond to telnet negotiations
+                    // Accept BINARY transmission (option 0) for reliable ZMODEM transfers
+                    const BINARY = 0
+                    if cmd == DO {
+                        if option == BINARY {
+                            response = append(response, IAC, WILL, option)
+                            c.telnetBinaryTX = true
+                        } else if option == TELOPT_NAWS {
+                            response = append(response, IAC, WILL, option)
+                            c.telnetNAWS = true
+                            // Immediately send current fixed NAWS
+                            // Will be written after loop
+                            response = append(response, c.buildNAWSSB()...)
+                        } else if option == TELOPT_TTYPE {
+                            response = append(response, IAC, WILL, option)
+                            c.telnetTTYPE = true
+                        } else {
+                            response = append(response, IAC, WONT, option)
+                        }
+                    } else if cmd == DONT {
+                        // Acknowledge with WONT
+                        response = append(response, IAC, WONT, option)
+                        if option == BINARY {
+                            c.telnetBinaryTX = false
+                        }
+                        if option == TELOPT_NAWS {
+                            c.telnetNAWS = false
+                        }
+                    } else if cmd == WILL {
+                        if option == BINARY {
+                            response = append(response, IAC, DO, option)
+                            c.telnetBinaryRX = true
+                        } else {
+                            response = append(response, IAC, DONT, option)
+                        }
+                    } else if cmd == WONT {
+                        // Acknowledge with DONT
+                        response = append(response, IAC, DONT, option)
+                        if option == BINARY {
+                            c.telnetBinaryRX = false
+                        }
+                    }
+                    i += 3
+                } else if data[i+1] == SB {
+                    // Handle subnegotiation
+                    j := i + 2
+                    if j >= len(data) {
+                        i += 2
+                        continue
+                    }
+                    opt := data[j]
+                    j++
+                    // Capture until IAC SE
+                    sbStart := j
+                    for j < len(data)-1 {
+                        if data[j] == IAC && data[j+1] == SE {
+                            sb := data[sbStart:j]
+                            // Process TTYPE SEND
+                            if opt == TELOPT_TTYPE {
+                                if len(sb) >= 1 && sb[0] == TELQUAL_SEND {
+                                    // Reply: IAC SB TTYPE IS "ansi" IAC SE
+                                    ttype := []byte{'a', 'n', 's', 'i'}
+                                    resp := []byte{IAC, SB, TELOPT_TTYPE, TELQUAL_IS}
+                                    resp = append(resp, ttype...)
+                                    resp = append(resp, IAC, SE)
+                                    response = append(response, resp...)
+                                }
+                            }
+                            i = j + 2
+                            break
+                        }
+                        j++
+                    }
+                    if j >= len(data)-1 {
+                        // Unterminated SB, drop remainder
+                        i = j
+                    }
+                } else {
+                    i += 2
+                }
+            } else {
+                i++
 			}
 		} else {
 			clean = append(clean, data[i])
@@ -592,7 +695,273 @@ func (c *Client) processTelnetData(data []byte) []byte {
         }
     }
 
-	return clean
+    return clean
+}
+
+// buildNAWSSB constructs a NAWS SB with current fixed cols/rows
+func (c *Client) buildNAWSSB() []byte {
+    const (
+        IAC  = 255
+        SB   = 250
+        SE   = 240
+        TELOPT_NAWS = 31
+    )
+    c.mu.Lock()
+    cols := c.termCols
+    rows := c.termRows
+    c.mu.Unlock()
+    if cols == 0 || rows == 0 {
+        cols = 80
+        rows = 25
+    }
+    // 16-bit big-endian values
+    widthHi := byte((cols >> 8) & 0xFF)
+    widthLo := byte(cols & 0xFF)
+    heightHi := byte((rows >> 8) & 0xFF)
+    heightLo := byte(rows & 0xFF)
+    return []byte{IAC, SB, TELOPT_NAWS, widthHi, widthLo, heightHi, heightLo, IAC, SE}
+}
+
+// sendTelnetNAWS sends the current fixed NAWS to the telnet peer
+func (c *Client) sendTelnetNAWS() {
+    sb := c.buildNAWSSB()
+    c.mu.Lock()
+    conn := c.telnet
+    c.mu.Unlock()
+    if conn != nil {
+        _, _ = conn.Write(sb)
+    }
+}
+
+// handleTerminalQueries detects DA/CPR requests in the data stream and replies
+// with conservative answers suitable for BBS detection.
+func (c *Client) handleTerminalQueries(data []byte) {
+    // Patterns to detect:
+    //  - ESC [ 6 n (CPR request)
+    //  - ESC [ c or ESC [ 0 c (Primary DA request)
+    //  - ESC Z (DECID)
+    for i := 0; i < len(data); i++ {
+        if data[i] != 0x1B { // ESC
+            continue
+        }
+        // Check for CSI sequences
+        if i+2 < len(data) && data[i+1] == '[' {
+            // Find final byte or stop after a few bytes
+            j := i + 2
+            // Collect parameters up to a small cap
+            for j < len(data) && j-i < 16 {
+                b := data[j]
+                if b >= 0x40 && b <= 0x7E { // final byte
+                    // CPR: ESC [ 6 n
+                    if b == 'n' {
+                        // DSR/CPR requests
+                        // ESC[6n -> Report cursor position
+                        if bytes.Equal(data[i:j+1], []byte{0x1B, '[', '6', 'n'}) {
+                            // Report tracked cursor position (only if CURSOR_TRACK is enabled)
+                            if os.Getenv("CURSOR_TRACK") == "true" {
+                                c.mu.Lock()
+                                row := c.cursorRow
+                                col := c.cursorCol
+                                c.mu.Unlock()
+                                if row <= 0 { row = 1 }
+                                if col <= 0 { col = 1 }
+                                rsp := fmt.Sprintf("\x1b[%d;%dR", row, col)
+                                log.Printf("CPR requested; replying %d;%d", row, col)
+                                c.sendTelnet([]byte(rsp))
+                            } else if os.Getenv("CPR_REPLY") == "true" {
+                                // Optional: reply 1;1 if explicitly enabled
+                                log.Printf("CPR requested; replying 1;1")
+                                c.sendTelnet([]byte{0x1B, '[', '1', ';', '1', 'R'})
+                            } else {
+                                log.Printf("CPR requested; suppressed")
+                            }
+                        }
+                        // ESC[5n -> Device Status Report (ready); reply ESC[0n
+                        if bytes.Equal(data[i:j+1], []byte{0x1B, '[', '5', 'n'}) {
+                            log.Printf("DSR(5n) requested; replying 0n")
+                            c.sendTelnet([]byte{0x1B, '[', '0', 'n'})
+                        }
+                    }
+                    // DA: ESC [ c or ESC [ 0 c
+                    if b == 'c' {
+                        // Reply VT102: ESC[?6c
+                        c.sendTelnet([]byte{0x1B, '[', '?', '6', 'c'})
+                    }
+                    break
+                }
+                j++
+            }
+            i = j
+            continue
+        }
+        // DECID: ESC Z
+        if i+1 < len(data) && data[i+1] == 'Z' {
+            // Respond with VT102 DA as well
+            c.sendTelnet([]byte{0x1B, '[', '?', '6', 'c'})
+            i++
+            continue
+        }
+    }
+}
+
+// sendTelnet writes raw bytes to the telnet connection if present
+func (c *Client) sendTelnet(b []byte) {
+    c.mu.Lock()
+    conn := c.telnet
+    c.mu.Unlock()
+    if conn != nil && len(b) > 0 {
+        _, _ = conn.Write(b)
+    }
+}
+
+// debugHexDump logs up to max bytes of data with a simple hex+ASCII view
+func (c *Client) debugHexDump(label string, data []byte, max int) {
+    if len(data) == 0 {
+        return
+    }
+    if max <= 0 || max > len(data) {
+        max = len(data)
+    }
+    const per = 16
+    log.Printf("HEX %s: %d bytes (showing %d)", label, len(data), max)
+    for off := 0; off < max; off += per {
+        end := off + per
+        if end > max {
+            end = max
+        }
+        // hex bytes
+        hex := make([]byte, 0, (end-off)*3)
+        ascii := make([]byte, 0, end-off)
+        for i := off; i < end; i++ {
+            b := data[i]
+            hex = append(hex, fmt.Sprintf("%02x ", b)...)
+            if b >= 32 && b <= 126 {
+                ascii = append(ascii, b)
+            } else {
+                ascii = append(ascii, '.')
+            }
+        }
+        log.Printf("%04x: %-48s |%s|", off, string(hex), string(ascii))
+    }
+}
+
+// updateCursorFrom parses a subset of ANSI to track cursor position
+func (c *Client) updateCursorFrom(data []byte) {
+    c.mu.Lock()
+    cols := c.termCols
+    rows := c.termRows
+    row := c.cursorRow
+    col := c.cursorCol
+    seq := append(c.cursorSeqBuf[:0], c.cursorSeqBuf...)
+    c.mu.Unlock()
+
+    // Helper to clamp
+    clamp := func() {
+        if cols <= 0 { cols = 80 }
+        if rows <= 0 { rows = 25 }
+        if row < 1 { row = 1 }
+        if col < 1 { col = 1 }
+        if row > rows { row = rows }
+        if col > cols { col = cols }
+    }
+
+    // Process stream with any leftover sequence start
+    buf := append(seq, data...)
+    i := 0
+    for i < len(buf) {
+        b := buf[i]
+        switch b {
+        case 0x0D: // CR
+            col = 1
+            i++
+        case 0x0A: // LF
+            row++
+            if row > rows { row = rows }
+            i++
+        case 0x1B: // ESC
+            if i+1 >= len(buf) {
+                // Incomplete
+                goto done
+            }
+            if buf[i+1] == '[' { // CSI
+                // Find final byte
+                j := i + 2
+                for j < len(buf) {
+                    fb := buf[j]
+                    if fb >= 0x40 && fb <= 0x7E {
+                        // Parse parameters
+                        params := string(buf[i+2 : j])
+                        // Split by ';'
+                        p := []int{}
+                        if len(params) > 0 {
+                            parts := strings.Split(params, ";")
+                            for _, s := range parts {
+                                if s == "" { s = "0" }
+                                if n, err := strconv.Atoi(s); err == nil { p = append(p, n) }
+                            }
+                        }
+                        // Final
+                        switch fb {
+                        case 'A': // CUU
+                            n := 1
+                            if len(p) >= 1 && p[0] > 0 { n = p[0] }
+                            row -= n
+                        case 'B': // CUD
+                            n := 1
+                            if len(p) >= 1 && p[0] > 0 { n = p[0] }
+                            row += n
+                        case 'C': // CUF
+                            n := 1
+                            if len(p) >= 1 && p[0] > 0 { n = p[0] }
+                            col += n
+                        case 'D': // CUB
+                            n := 1
+                            if len(p) >= 1 && p[0] > 0 { n = p[0] }
+                            col -= n
+                        case 'H', 'f': // CUP/HVP
+                            r := 1
+                            c2 := 1
+                            if len(p) >= 1 && p[0] > 0 { r = p[0] }
+                            if len(p) >= 2 && p[1] > 0 { c2 = p[1] }
+                            row = r
+                            col = c2
+                        case 'J': // ED (ignore position change)
+                            // no-op
+                        case 'K': // EL
+                            // no-op
+                        }
+                        clamp()
+                        i = j + 1
+                        goto next
+                    }
+                    j++
+                }
+                // Incomplete CSI
+                goto done
+            } else {
+                // Unsupported ESC sequence start; treat as incomplete
+                goto done
+            }
+        default:
+            // Printable?
+            if b >= 0x20 {
+                col++
+                if col > cols { col = cols }
+            }
+            i++
+        }
+    next:
+    }
+done:
+    // Save leftovers
+    c.mu.Lock()
+    c.cursorRow = row
+    c.cursorCol = col
+    c.cursorSeqBuf = c.cursorSeqBuf[:0]
+    if i < len(buf) {
+        c.cursorSeqBuf = append(c.cursorSeqBuf, buf[i:]...)
+    }
+    c.mu.Unlock()
 }
 
 func (c *Client) connectSSH(host string, port int, username, password string) {
@@ -672,39 +1041,47 @@ func (c *Client) connectSSH(host string, port int, username, password string) {
 func (c *Client) handleSSHSession(session *ssh.Session) {
     defer session.Close()
 
-	stdout, err := session.StdoutPipe()
-	if err != nil {
-		c.sendMessage("error", err.Error())
-		return
-	}
+    stdout, err := session.StdoutPipe()
+    if err != nil {
+        c.sendMessage("error", err.Error())
+        return
+    }
 
-	buffer := make([]byte, 8192)
-	for {
-		n, err := stdout.Read(buffer)
-		if err != nil {
-			c.sendJSON(Message{Type: "disconnected"})
-			c.disconnect()
-			return
-		}
+    buffer := make([]byte, 8192)
+    for {
+        n, err := stdout.Read(buffer)
+        if err != nil {
+            c.sendJSON(Message{Type: "disconnected"})
+            c.disconnect()
+            return
+        }
 
         if n > 0 {
+            // Process ANSI normalization first
+            processed := buffer[:n]
+            if c.ansiEnhanced != nil {
+                processed = c.ansiEnhanced.ProcessANSIData(processed)
+            }
+            if os.Getenv("HEX_DUMP") == "true" {
+                c.debugHexDump("SSH->CLIENT", processed, 256)
+            }
             // Convert CP437 to UTF-8 if needed
             var outputData []byte
             if c.charset == "CP437" {
-                utf8String := ConvertCP437ToUTF8Enhanced(buffer[:n])
+                utf8String := ConvertCP437ToUTF8Enhanced(processed)
                 outputData = []byte(utf8String)
             } else {
-                outputData = buffer[:n]
+                outputData = processed
             }
 
-			encoded := base64.StdEncoding.EncodeToString(outputData)
-			c.sendJSON(Message{
-				Type:     "data",
-				Data:     encoded,
-				Encoding: "base64",
-			})
-		}
-	}
+            encoded := base64.StdEncoding.EncodeToString(outputData)
+            c.sendJSON(Message{
+                Type:     "data",
+                Data:     encoded,
+                Encoding: "base64",
+            })
+        }
+    }
 }
 
 // sendToRemote forwards user keystrokes to the active remote (telnet/SSH),

--- a/static/ansi-music.js
+++ b/static/ansi-music.js
@@ -1,0 +1,98 @@
+// Minimal ANSI Music player for SyncTERM-style CSI | sequences.
+// Payload grammar varies wildly; for now, support a tiny subset:
+//  - Tn   : tempo (BPM) e.g., T120
+//  - On   : octave 0-8
+//  - Ln   : default note length (e.g., 4 = quarter, 8 = eighth)
+//  - Notes: C D E F G A B, with optional #, and optional length after note (e.g., C8)
+//  - Rn   : rest with optional length
+// Unknown tokens are ignored. This is intentionally conservative.
+
+class AnsiMusicPlayer {
+  constructor() {
+    this.ctx = null;
+    this.tempo = 120; // BPM
+    this.octave = 4;  // Default octave
+    this.defLen = 4;  // Default length denominator
+    this.queue = Promise.resolve();
+  }
+
+  ensureCtx() {
+    if (!this.ctx) {
+      const AC = window.AudioContext || window.webkitAudioContext;
+      if (!AC) return false;
+      this.ctx = new AC();
+    }
+    return true;
+  }
+
+  noteFreq(note, octave) {
+    const base = { C:0, 'C#':1, D:2, 'D#':3, E:4, F:5, 'F#':6, G:7, 'G#':8, A:9, 'A#':10, B:11 };
+    const semi = base[note];
+    if (semi == null) return null;
+    // A4 = 440 Hz, note number 69
+    const n = semi + (octave+1)*12; // C0=12
+    return 440 * Math.pow(2, (n - 69)/12);
+  }
+
+  durMs(den) {
+    const beatMs = 60000/Math.max(30, Math.min(300, this.tempo));
+    return (4/den) * beatMs;
+  }
+
+  playTone(freq, ms) {
+    if (!this.ensureCtx()) return Promise.resolve();
+    const ctx = this.ctx;
+    const t0 = ctx.currentTime;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'square';
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(0.0001, t0);
+    gain.gain.exponentialRampToValueAtTime(0.2, t0 + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + ms/1000);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(t0);
+    osc.stop(t0 + ms/1000 + 0.02);
+    return new Promise(res => setTimeout(res, ms * 0.95));
+  }
+
+  rest(ms) {
+    return new Promise(res => setTimeout(res, ms));
+  }
+
+  parseAndQueue(payload) {
+    // Ensure context and try to resume on first use
+    if (this.ensureCtx() && this.ctx.state === 'suspended') {
+      try { this.ctx.resume(); } catch {}
+    }
+    // Tokenize by simple regex: commands like T120, O4, L8, R4, C#4, etc.
+    const re = /(T\d+|O\d+|L\d+|R\d+|[A-G]#?\d*)/gi;
+    const tokens = payload.match(re) || [];
+    for (const tok of tokens) {
+      const T = tok.toUpperCase();
+      if (T[0] === 'T') {
+        const n = parseInt(T.slice(1), 10); if (!isNaN(n)) this.tempo = Math.max(30, Math.min(300, n));
+      } else if (T[0] === 'O') {
+        const n = parseInt(T.slice(1), 10); if (!isNaN(n)) this.octave = Math.max(0, Math.min(8, n));
+      } else if (T[0] === 'L') {
+        const n = parseInt(T.slice(1), 10); if (!isNaN(n)) this.defLen = Math.max(1, Math.min(64, n));
+      } else if (T[0] === 'R') {
+        const n = parseInt(T.slice(1), 10) || this.defLen;
+        const ms = this.durMs(n);
+        this.queue = this.queue.then(() => this.rest(ms));
+      } else {
+        // Note
+        const m = /^([A-G]#?)(\d+)?$/.exec(T);
+        if (!m) continue;
+        const name = m[1];
+        const len = m[2] ? parseInt(m[2], 10) : this.defLen;
+        const freq = this.noteFreq(name, this.octave);
+        if (!freq) continue;
+        const ms = this.durMs(len);
+        this.queue = this.queue.then(() => this.playTone(freq, ms));
+      }
+    }
+  }
+}
+
+window.AnsiMusicPlayer = AnsiMusicPlayer;

--- a/static/index.html
+++ b/static/index.html
@@ -132,6 +132,7 @@
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-webgl@0.16.0/lib/xterm-addon-webgl.js"></script>
     <script src="zmodem.min.js"></script>
     <script src="zmodem-lib.js"></script>
+    <script src="ansi-music.js"></script>
     <script src="directory.js?v=4"></script>
     <script src="auth.js?v=5"></script>
     <script src="app.js?v=8"></script>


### PR DESCRIPTION
This PR improves terminal compatibility and adds basic ANSI music playback.\n\nHighlights:\n- Cursor home after ESC[2J to match classic behavior (fixes left alignment after clear).\n- Immediate handling of single-char ESC: save/restore cursor (ESC 7/8), RIS/IND/RI/NEL.\n- Normalize 8-bit C1 controls (CSI/OSC/DCS/ST) to ESC-prefixed sequences.\n- Telnet: fixed-size NAWS/TTYPE; conservative DA/CPR/DSR replies (disabled by default, togglable).\n- SSH path now also applies ANSI normalization.\n- Client debugging helpers: dumpCell/ dumpLine/ dumpRegion.\n- ANSI music support: detect CSI |/M/N sequences, suppress from display, send payload to client; client WebAudio player supports T/O/L, notes with optional # and lengths, and rests.\n\nNotes:\n- Music and terminal answers are off by default to avoid side effects; can be enabled via ENV toggles.\n- Focused changes; no unrelated refactors.\n\nTested against boards that clear the screen before drawing (alignment fixed) and boards emitting ANSI music sequences (no text leakage; audio plays).