### PR TITLE
feat: Add BBS quick link feature with URL slugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 !go.sum
 !main.go
 !proxy.go
+!slug.go
 !zmodem_lrzsz.go
 
 # Allow the static directory itself, but only whitelist specific files inside
@@ -37,6 +38,16 @@
 !static/app.js
 !static/ansi-music.js
 !static/favicon.svg
+
+# Allow packaging directory and essential files
+!packaging/
+!packaging/build.sh
+!packaging/build-test.sh
+!packaging/VERSION
+!packaging/config.json.template
+!packaging/debian-template/
+!packaging/debian-template/**
+!packaging/nginx-test.conf
 
 # Allow GitHub Actions workflows
 !.github/

--- a/.gitignore
+++ b/.gitignore
@@ -39,15 +39,6 @@
 !static/ansi-music.js
 !static/favicon.svg
 
-# Allow packaging directory and essential files
-!packaging/
-!packaging/build.sh
-!packaging/build-test.sh
-!packaging/VERSION
-!packaging/config.json.template
-!packaging/debian-template/
-!packaging/debian-template/**
-!packaging/nginx-test.conf
 
 # Allow GitHub Actions workflows
 !.github/

--- a/api.go
+++ b/api.go
@@ -48,3 +48,47 @@ func handleGetDefaultBBSList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
+
+// handleGetBBSBySlug returns BBS information based on slug
+func handleGetBBSBySlug(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract slug from URL path
+	slug := r.URL.Query().Get("slug")
+	if slug == "" {
+		http.Error(w, "Missing slug parameter", http.StatusBadRequest)
+		return
+	}
+
+	// Get BBS directory entries
+	entries, err := GetBBSDirectoryEntries()
+	if err != nil {
+		http.Error(w, "Failed to load BBS directory", http.StatusInternalServerError)
+		return
+	}
+
+	// Find BBS by slug
+	bbs := FindBBSBySlug(slug, entries)
+	if bbs == nil {
+		http.Error(w, "BBS not found", http.StatusNotFound)
+		return
+	}
+
+	// Convert to BBSInfo format for client
+	bbsInfo := BBSInfo{
+		ID:          bbs.ID,
+		Name:        bbs.Name,
+		Host:        bbs.Host,
+		Port:        bbs.Port,
+		Protocol:    bbs.Protocol,
+		Description: bbs.Description,
+		Encoding:    bbs.Encoding,
+		Location:    bbs.Location,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(bbsInfo)
+}

--- a/bbs_directory.go
+++ b/bbs_directory.go
@@ -29,6 +29,7 @@ type BBSEntry struct {
 	Software    string `json:"software"`
 	Active      bool   `json:"active"`
 	IsFavorite  bool   `json:"is_favorite,omitempty"`
+	Slug        string `json:"slug"`
 }
 
 // LoadBBSFromCSV loads BBS entries from a CSV file with header
@@ -136,6 +137,7 @@ func LoadBBSFromCSV(filename string) ([]BBSEntry, error) {
             Software:    software,
             Location:    location,
             Active:      true,
+            Slug:        GenerateSlug(name),
         }
 
         entries = append(entries, entry)

--- a/slug.go
+++ b/slug.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// GenerateSlug creates a URL-friendly slug from a BBS name
+func GenerateSlug(name string) string {
+	// Convert to lowercase
+	slug := strings.ToLower(name)
+
+	// Replace spaces and common separators with hyphens
+	slug = regexp.MustCompile(`[\s_]+`).ReplaceAllString(slug, "-")
+
+	// Remove any characters that aren't alphanumeric or hyphens
+	slug = regexp.MustCompile(`[^a-z0-9-]+`).ReplaceAllString(slug, "")
+
+	// Remove leading/trailing hyphens
+	slug = strings.Trim(slug, "-")
+
+	// Collapse multiple hyphens into one
+	slug = regexp.MustCompile(`-+`).ReplaceAllString(slug, "-")
+
+	return slug
+}
+
+// FindBBSBySlug searches for a BBS entry by its slug
+func FindBBSBySlug(slug string, bbsList []BBSEntry) *BBSEntry {
+	for _, bbs := range bbsList {
+		if GenerateSlug(bbs.Name) == slug {
+			return &bbs
+		}
+	}
+	return nil
+}

--- a/static/app.js
+++ b/static/app.js
@@ -988,6 +988,43 @@ class BBSTerminal {
 }
 
 // Initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     window.bbsTerminal = new BBSTerminal();
+
+    // Check for BBS slug in URL path
+    const path = window.location.pathname;
+    const pathParts = path.split('/').filter(part => part);
+
+    if (pathParts.length === 1 && pathParts[0] !== '') {
+        const slug = pathParts[0];
+
+        try {
+            // Fetch BBS info by slug
+            const response = await fetch(`/api/bbs-by-slug?slug=${encodeURIComponent(slug)}`);
+
+            if (response.ok) {
+                const bbs = await response.json();
+
+                // Auto-connect to the BBS
+                setTimeout(() => {
+                    window.bbsTerminal.connectToBBS(
+                        bbs.host,
+                        bbs.port || 23,
+                        bbs.protocol || 'telnet',
+                        '',  // username
+                        '',  // password
+                        bbs.encoding || 'CP437'
+                    );
+
+                    // Update the current BBS display
+                    const currentBBSElement = document.getElementById('current-bbs');
+                    if (currentBBSElement) {
+                        currentBBSElement.textContent = bbs.name;
+                    }
+                }, 500); // Small delay to ensure terminal is ready
+            }
+        } catch (error) {
+            console.error('Error fetching BBS by slug:', error);
+        }
+    }
 });

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes">
     <title>RetroTerm - BBS Terminal</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css">
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=5">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body>
@@ -134,7 +134,7 @@
     <script src="zmodem-lib.js"></script>
     <script src="ansi-music.js"></script>
     <script src="directory.js?v=4"></script>
-    <script src="auth.js?v=5"></script>
+    <script src="auth.js?v=8"></script>
     <script src="app.js?v=8"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -1161,5 +1161,69 @@ body.mobile-mode #terminal-container .terminal {
 .dirflat-table tbody tr { cursor: pointer; transition: background 0.2s; }
 .dirflat-table tbody tr:hover { background: rgba(255,255,255,0.05); }
 .dirflat-table td.addr { font-family: 'Courier New', monospace; color: var(--text-secondary); }
-.dirflat-table td.name { color: var(--text-primary); font-weight: 600; }
+.dirflat-table td.name { color: var(--text-primary); }
 .dirflat-table td.software { color: var(--text-secondary); }
+
+/* Quick link inline styling */
+.quick-link-wrapper {
+    position: relative;
+    display: inline-block;
+    margin-left: 0.5rem;
+}
+
+.quick-link-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.85rem;
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    transition: all 0.2s;
+    opacity: 0.6;
+    vertical-align: middle;
+}
+
+.quick-link-btn:hover {
+    opacity: 1;
+    color: var(--accent-primary);
+    background: var(--bg-tertiary);
+}
+
+.quick-link-tooltip {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%) translateY(-5px);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    padding: 0.4rem 0.6rem;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+}
+
+.quick-link-wrapper:hover .quick-link-tooltip {
+    opacity: 1;
+}
+
+.quick-link-tooltip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 5px;
+    border-style: solid;
+    border-color: var(--bg-tertiary) transparent transparent transparent;
+}
+
+.bbs-name {
+    font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- Add URL-friendly slug generation for BBS names allowing direct access via short URLs (e.g., `/realm-of-serion`)
- Implement auto-connect functionality when visiting quick links
- Add copy link button in BBS directory with hover tooltip

## Changes
- **Backend**:
  - Generate URL slugs from BBS names in `slug.go`
  - Add `/api/bbs-by-slug` endpoint for slug lookups
  - Implement slug-based routing in main handler
  
- **Frontend**:
  - Auto-detect and connect to BBS when visiting slug URL
  - Add copy quick link button in directory with tooltip
  - Map slug field through to frontend BBS data

- **Build Scripts**:
  - Fix permission issues in packaging scripts (directories need 755, files 644)
  - Add test subdomain nginx configuration

## Test Plan
- [x] Visit a quick link URL (e.g., `/realm-of-serion`) and verify auto-connect
- [x] Copy quick link from directory and verify it works
- [x] Test on both production and test environments
- [x] Verify build scripts create packages with correct permissions

## Notes
Version bumped to 0.1.13 for this release.